### PR TITLE
chore(deps): use fully qualified container image name for Gitea

### DIFF
--- a/docker-compose/gitea/compose.yaml
+++ b/docker-compose/gitea/compose.yaml
@@ -1,7 +1,7 @@
 ---
 services:
   server:
-    image: gitea/gitea:1.23.8
+    image: docker.io/gitea/gitea:1.23.8
     container_name: gitea-server
     environment:
       - USER_UID=1000
@@ -58,7 +58,7 @@ services:
 
 # --> When using internal database
 # db:
-#   image: postgres:14
+#   image: docker.io/library/postgres:17.5
 #   container_name: gitea-db
 #   environment:
 #     - POSTGRES_USER=${POSTGRES_USER:?POSTGRES_USER not set}


### PR DESCRIPTION
Use fully qualified container image name for Gitea.

While doing so, also bump PostgreSQL to the latest stable version.